### PR TITLE
overhang

### DIFF
--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -23,6 +23,7 @@ export default class Toolbar extends React.Component {
     editorNode: PropTypes.object,
     setLink: PropTypes.func,
     focus: PropTypes.func,
+    maxOverhang: PropTypes.number,
   };
 
   static defaultProps = {
@@ -60,50 +61,60 @@ export default class Toolbar extends React.Component {
   }
 
   componentDidUpdate() {
+    // eslint-disable-next-line react/no-find-dom-node
+    const toolbarNode = this._toolbarNode;
+    const selectionState = this.props.editorState.getSelection();
+
+    if (selectionState.isCollapsed()) {
+      toolbarNode.style.cssText = '';
+    }
+
     if (!this.props.editorEnabled || this.state.showURLInput) {
       return;
     }
-    const selectionState = this.props.editorState.getSelection();
     if (selectionState.isCollapsed()) {
       return;
     }
+    const maxOverhang = this.props.maxOverhang;
     // eslint-disable-next-line no-undef
     const nativeSelection = getSelection(window);
     if (!nativeSelection.rangeCount) {
       return;
     }
     const selectionBoundary = getSelectionRect(nativeSelection);
-
-    // eslint-disable-next-line react/no-find-dom-node
-    const toolbarNode = ReactDOM.findDOMNode(this);
     const toolbarBoundary = toolbarNode.getBoundingClientRect();
 
     // eslint-disable-next-line react/no-find-dom-node
     const parent = ReactDOM.findDOMNode(this.props.editorNode);
     const parentBoundary = parent.getBoundingClientRect();
-
+    // eslint-disable-next-line
+    console.log(parentBoundary);
     /*
     * Main logic for setting the toolbar position.
     */
+
     toolbarNode.style.top =
       `${(selectionBoundary.top - parentBoundary.top - toolbarBoundary.height - 5)}px`;
-    toolbarNode.style.width = `${toolbarBoundary.width}px`;
+    // toolbarNode.style.width = `${toolbarBoundary.width}px`;
     const widthDiff = selectionBoundary.width - toolbarBoundary.width;
     if (widthDiff >= 0) {
-      toolbarNode.style.left = `${widthDiff / 2}px`;
+      toolbarNode.style.left =
+        `${(selectionBoundary.left - parentBoundary.left) + (widthDiff / 2)}px`;
     } else {
-      const left = (selectionBoundary.left - parentBoundary.left);
-      toolbarNode.style.left = `${left + (widthDiff / 2)}px`;
-      // toolbarNode.style.width = toolbarBoundary.width + 'px';
-      // if (left + toolbarBoundary.width > parentBoundary.width) {
-        // toolbarNode.style.right = '0px';
-        // toolbarNode.style.left = '';
-        // toolbarNode.style.width = toolbarBoundary.width + 'px';
-      // }
-      // else {
-      //   toolbarNode.style.left = (left + widthDiff / 2) + 'px';
-      //   toolbarNode.style.right = '';
-      // }
+      let left = (selectionBoundary.left - parentBoundary.left);
+      left += (widthDiff / 2);
+      const initialLeft = left;
+
+      if ((left + toolbarBoundary.width) > (parentBoundary.width + maxOverhang)) {
+        left = (parentBoundary.width - toolbarBoundary.width) + maxOverhang;
+      }
+      if (left < -maxOverhang) left = -maxOverhang;
+      toolbarNode.style.left = `${left}px`;
+
+      let arrowLeft = (initialLeft - left) + (toolbarBoundary.width / 2);
+      if (arrowLeft < 9) arrowLeft = 9;
+      if (arrowLeft > (toolbarBoundary.width - 9)) arrowLeft = toolbarBoundary.width - 9;
+      this._arrowNode.style.left = `${arrowLeft}px`;
     }
   }
 
@@ -193,6 +204,7 @@ export default class Toolbar extends React.Component {
     if (!editorEnabled || editorState.getSelection().isCollapsed()) {
       isOpen = false;
     }
+
     if (showURLInput) {
       let className = `md-editor-toolbar${(isOpen ? ' md-editor-toolbar--isopen' : '')}`;
       className += ' md-editor-toolbar--linkinput';
@@ -236,6 +248,7 @@ export default class Toolbar extends React.Component {
     return (
       <div
         className={`md-editor-toolbar${(isOpen ? ' md-editor-toolbar--isopen' : '')}`}
+        ref={(node) => { this._toolbarNode = node; }}
       >
         {this.props.blockButtons.length > 0 ? (
           <BlockToolbar
@@ -244,6 +257,7 @@ export default class Toolbar extends React.Component {
             buttons={this.props.blockButtons}
           />
         ) : null}
+        <div className="md-editor-toolbar--arrow" ref={(node) => { this._arrowNode = node; }} />
         {this.props.inlineButtons.length > 0 ? (
           <InlineToolbar
             editorState={editorState}
@@ -342,4 +356,3 @@ export const INLINE_BUTTONS = [
   //   style: 'CODE',
   //   description: 'Inline Code',
   // },
-

--- a/src/components/toolbar.scss
+++ b/src/components/toolbar.scss
@@ -35,15 +35,16 @@ $toolbar-color: #2b2b2b;
   z-index: 2;
   position: absolute;
   transition: all 0.1s ease;
-  visibility: hidden;
+  // visibility: hidden;
+  display: none;
   background-image: linear-gradient(to bottom,rgba(49,49,47,.99),#262625);
-
   // transition: top 75ms ease-out,left 75ms ease-out;
 
   &.md-editor-toolbar--isopen {
-    visibility: visible;
+    // visibility: visible;
+    display: flex;
     // transition: top 75ms ease-out,left 75ms ease-out;
-    // animation: pop-upwards 180ms forwards linear;
+    animation: pop-upwards 180ms forwards linear;
   }
 
   &.md-editor-toolbar--linkinput {
@@ -51,7 +52,7 @@ $toolbar-color: #2b2b2b;
     animation: pop-downwards 200ms forwards linear;
   }
 
-  &::after {
+  .md-editor-toolbar--arrow {
     content: "";
     position: absolute;
     bottom: -5px;
@@ -93,7 +94,7 @@ $toolbar-color: #2b2b2b;
 .md-RichEditor-controls {
   font-family: 'Helvetica', sans-serif;
   font-size: 14px;
-  display: inline-block;
+  display: flex;
   border-right: 1px solid #555;
   position: relative;
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -65,6 +65,7 @@ class MediumDraftEditor extends React.Component {
     handleKeyCommand: PropTypes.func,
     handleReturn: PropTypes.func,
     disableToolbar: PropTypes.bool,
+    maxOverhang: PropTypes.number,
   };
 
   static defaultProps = {
@@ -95,6 +96,7 @@ class MediumDraftEditor extends React.Component {
       },
     ],
     disableToolbar: false,
+    maxOverhang: 0,
   };
 
   constructor(props) {
@@ -372,6 +374,7 @@ class MediumDraftEditor extends React.Component {
               focus={this.focus}
               blockButtons={this.props.blockButtons}
               inlineButtons={this.props.inlineButtons}
+              maxOverhang={this.props.maxOverhang}
             />
           )}
         </div>


### PR DESCRIPTION
Hi,

First off, great editor! I made some changes for my own implementation of this, and would like to give them back. This pull request enables an `maxOverhang` property. This sets the maximum number of pixels the menu can go over the viewport on the left and right side. Set it to 0 if you do not want it to  go pass the viewport.

Cheers,

Jaap