### PR TITLE
Exporter type of Block.BREAK causing errors with react-dom

### DIFF
--- a/src/exporter.js
+++ b/src/exporter.js
@@ -80,7 +80,7 @@ export const blockToHTML = (block) => {
       };
     }
     case Block.BREAK:
-      return <div className={`md-block-${blockType.toLowerCase()}`} />;
+      return <div className={`md-block-${blockType.toLowerCase().replace(':', '-')}`} />;
     case Block.BLOCKQUOTE:
       return <blockquote className={`md-block-${blockType.toLowerCase()}`} />;
     case Block.OL:

--- a/src/exporter.js
+++ b/src/exporter.js
@@ -80,7 +80,7 @@ export const blockToHTML = (block) => {
       };
     }
     case Block.BREAK:
-      return <hr className={`md-block-${blockType.toLowerCase()}`} />;
+      return <div className={`md-block-${blockType.toLowerCase()}`} />;
     case Block.BLOCKQUOTE:
       return <blockquote className={`md-block-${blockType.toLowerCase()}`} />;
     case Block.OL:


### PR DESCRIPTION
When using the exporter to get the output in HTML, the default Block.BREAK converts to an` <hr />` but in React it fails the react-dom invariant function check:

`
Uncaught Error: hr is a void element tag and must neither have 'children' nor use 'dangerouslySetInnerHTML'.
    at invariant (invariant.js:44)
    at assertValidProps (ReactDOMComponent.js:140)
    at ReactDOMComponent.mountComponent (ReactDOMComponent.js:446)
    at Object.mountComponent (ReactReconciler.js:46)
    at eval (ReactServerRendering.js:45)
    at ReactServerRenderingTransaction.perform (Transaction.js:140)
    at renderToStringImpl (ReactServerRendering.js:43)
    at Object.renderToStaticMarkup (ReactServerRendering.js:83)
    at splitReactElement (splitReactElement.js:23)
    at getBlockTags (getBlockTags.js:38)
`

This is how I worked around the issue, by changing it to a div and then restyling it to mimic the behavior of an `<hr />`.. this might not be the best approach, this PR is just a way of suggesting and starting a discussion.

Thanks