### PR TITLE
Fix for issue with unintentional navigation when adding link

### DIFF
--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -128,7 +128,7 @@ export default class Toolbar extends React.Component {
   }
 
   handleLinkInput(e, direct = false) {
-    if (!direct) {
+    if (direct !== true) {
       e.preventDefault();
       e.stopPropagation();
     }


### PR DESCRIPTION
The issue seem to stem from react sometimes giving two arguments on click, one synthetic event and one real.

To mitigate this issue we should type-check, then we will skip preventDefault only when we actually want it to be skipped (I know it's not as pretty but it should fix the issue).