### PR TITLE
Pass rest of the props down into Button component

### DIFF
--- a/src/components/addbutton.js
+++ b/src/components/addbutton.js
@@ -164,6 +164,7 @@ export default class AddButton extends React.Component {
                 const Button = button.component;
                 return (
                   <Button
+                    {...button}
                     key={button.title}
                     getEditorState={this.props.getEditorState}
                     setEditorState={this.props.setEditorState}


### PR DESCRIPTION
This way, custom sidebar components can receive props like `apiEndpoint` or `imageTitle` when declared at `sideButtons` prop.

````
const API_ENDPOINT = "https://exampe.com";

<Editor
  sideButtons={[
    {
      title: 'Image',
      component: CustomImageButton,
      apiEndpoint: `${API_ENDPOINT}/some/api`,
      imageName: "my-seo-friendly-title.jpeg"
    }
  ]}
  ref="editor"
  editorState={editorState}
  onChange={this.onChange} />
````