### PR TITLE
Add ability to configure toolbar (block and inline styles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ A medium like rich text editor built upon [draft-js](https://facebook.github.io/
     - `caption` - Can be used as a caption for media blocks like image or video instead of nested `draft-js` instances for simplicity.
     - `block-quote-caption` - Caption for `blockquote`s.
     - `todo` - Todo text with a checkbox.
+- Easily customizable toolbar via `toolbarConfig` for the following block and inline styles. Defaults to all. Case sensitive.
+     - `block: ['ordered-list-item', 'unordered-list-item', 'blockquote', 'header-three', 'todo']`
+     - `inline: ['BOLD', 'ITALIC', 'UNDERLINE', 'hyperlink', 'HIGHLIGHT']`
+
 
 ##### Following are the keyboard shortcuts to toggle block types (<kbd>Alt and CTRL</kbd> for Windows/Linux and <kbd>Option and Command</kbd> for OSX)
 *   <kbd>Alt/Option</kbd> +

--- a/src/editor.js
+++ b/src/editor.js
@@ -85,6 +85,7 @@ class MediumDraftEditor extends React.Component {
     handleReturn: PropTypes.func,
     disableToolbar: PropTypes.bool,
     showLinkEditToolbar: PropTypes.bool,
+    toolbarConfig: PropTypes.object,
   };
 
   static defaultProps = {
@@ -116,6 +117,7 @@ class MediumDraftEditor extends React.Component {
     ],
     disableToolbar: false,
     showLinkEditToolbar: true,
+    toolbarConfig: {},
   };
 
   constructor(props) {
@@ -215,6 +217,39 @@ class MediumDraftEditor extends React.Component {
       entityKey = contentWithEntity.getLastCreatedEntityKey();
     }
     this.onChange(RichUtils.toggleLink(editorState, selection, entityKey), this.focus);
+  }
+
+  /**
+   * Override which text modifications are available according BLOCK_BUTTONS style property.
+   * Defaults all of them if no toolbarConfig.block passed:
+   *   block: ['ordered-list-item', 'unordered-list-item', 'blockquote', 'header-three', 'todo'],
+   * Example parameter: toolbarConfig = {
+   *   block: ['ordered-list-item', 'unordered-list-item'],
+   *   inline: ['BOLD', 'ITALIC', 'UNDERLINE', 'hyperlink'],
+   * };
+   */
+  configureToolbarBlockOptions(toolbarConfig) {
+    return toolbarConfig && toolbarConfig.block
+      ? toolbarConfig.block.map(type => BLOCK_BUTTONS.find(button => button.style === type))
+        .filter(button => button !== undefined)
+      : BLOCK_BUTTONS;
+  }
+
+  /**
+   * Override which text modifications are available according INLINE_BUTTONS style property.
+   * CASE SENSITIVE. Would be good clean up to lowercase inline styles consistently.
+   * Defaults all of them if no toolbarConfig.inline passed:
+   *   inline: ['BOLD', 'ITALIC', 'UNDERLINE', 'hyperlink', 'HIGHLIGHT'],
+   * Example parameter: toolbarConfig = {
+   *   block: ['ordered-list-item', 'unordered-list-item'],
+   *   inline: ['BOLD', 'ITALIC', 'UNDERLINE', 'hyperlink'],
+   * };
+   */
+  configureToolbarInlineOptions(toolbarConfig) {
+    return toolbarConfig && toolbarConfig.inline
+      ? toolbarConfig.inline.map(type => INLINE_BUTTONS.find(button => button.style === type))
+        .filter(button => button !== undefined)
+      : INLINE_BUTTONS;
   }
 
   /*
@@ -450,13 +485,15 @@ class MediumDraftEditor extends React.Component {
   Renders the `Editor`, `Toolbar` and the side `AddButton`.
   */
   render() {
-    const { editorState, editorEnabled, disableToolbar, showLinkEditToolbar } = this.props;
+    const { editorState, editorEnabled, disableToolbar, showLinkEditToolbar, toolbarConfig } = this.props;
     const showAddButton = editorEnabled;
     const editorClass = `md-RichEditor-editor${!editorEnabled ? ' md-RichEditor-readonly' : ''}`;
     let isCursorLink = false;
     if (editorEnabled && showLinkEditToolbar) {
       isCursorLink = isCursorBetweenLink(editorState);
     }
+    this.blockButtons = this.configureToolbarBlockOptions(toolbarConfig);
+    this.inlineButtons = this.configureToolbarInlineOptions(toolbarConfig);
     return (
       <div className="md-RichEditor-root">
         <div className={editorClass}>
@@ -498,8 +535,8 @@ class MediumDraftEditor extends React.Component {
               editorEnabled={editorEnabled}
               setLink={this.setLink}
               focus={this.focus}
-              blockButtons={this.props.blockButtons}
-              inlineButtons={this.props.inlineButtons}
+              blockButtons={this.blockButtons}
+              inlineButtons={this.inlineButtons}
             />
           )}
           {isCursorLink && (


### PR DESCRIPTION
Followup PR for https://github.com/brijeshb42/medium-draft/pull/99. First PR got corrupted.

Adds ability to configure (in my case, limit) which styles are available for text editing. Allows for changing toolbar dynamically.