### PR TITLE
Updating draft-convert to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.5",
   "description": "A medium like rich text editor built upon draft-js with an emphasis on eliminating mouse usage by adding relevant keyboard shortcuts",
   "main": "lib/index.js",
+  "repository": "https://github.com/brijeshb42/medium-draft",
   "scripts": {
     "start": "npm run dev",
     "clean": "rm -f dist/*.js && rm -f dist/*.css && rm -rf lib",
@@ -36,7 +37,7 @@
   "peerDependencies": {
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "draft-convert": "^1.3.3"
+    "draft-convert": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
@@ -51,7 +52,7 @@
     "babel-preset-react": "^6.5.0",
     "chai": "^3.5.0",
     "css-loader": "^0.23.1",
-    "draft-convert": "^1.3.3",
+    "draft-convert": "^2.0.0",
     "enzyme": "^2.8.2",
     "eslint": "^3.3.1",
     "eslint-config-airbnb": "^10.0.1",

--- a/src/importer.js
+++ b/src/importer.js
@@ -1,5 +1,4 @@
 import { convertFromHTML } from 'draft-convert';
-import { Entity } from 'draft-js';
 import { Inline, Block, Entity as EntityType } from './util/constants';
 
 export const htmlToStyle = (nodeName, node, currentStyle) => {
@@ -26,9 +25,9 @@ export const htmlToStyle = (nodeName, node, currentStyle) => {
   return currentStyle;
 };
 
-export const htmlToEntity = (nodeName, node) => {
+export const htmlToEntity = (nodeName, node, createEntity) => {
   if (nodeName === 'a') {
-    return Entity.create(EntityType.LINK, 'MUTABLE', { url: node.href });
+    return createEntity(EntityType.LINK, 'MUTABLE', { url: node.href });
   }
   return undefined;
 };


### PR DESCRIPTION
There were a few pesky warnings on draftEntity.create which draft convert v2 seems to have solved by passing in contentState.createEntity as a third param. This PR merely bumps the package versions, uses the passed method and drops the import of draft.js, since it is no longer needed.