### PR TITLE
Pass return event through to handleReturn from props

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -357,7 +357,7 @@ class MediumDraftEditor extends React.Component {
   */
   handleReturn(e) {
     if (this.props.handleReturn) {
-      const behavior = this.props.handleReturn();
+      const behavior = this.props.handleReturn(e);
       if (behavior === HANDLED || behavior === true) {
         return HANDLED;
       }


### PR DESCRIPTION
Just passing the event through to the function specified in props.