### PR TITLE
update README.md for React refs deprecreated

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,20 @@ class App extends React.Component {
     this.onChange = (editorState) => {
       this.setState({ editorState });
     };
+
+    this.refsEditor = React.createRef();
+
   }
 
   componentDidMount() {
-    this.refs.editor.focus();
+    this.refsEditor.current.focus();
   }
 
   render() {
     const { editorState } = this.state;
     return (
       <Editor
-        ref="editor"
+        ref={this.refsEditor}
         editorState={editorState}
         onChange={this.onChange} />
     );

--- a/README.md
+++ b/README.md
@@ -253,17 +253,20 @@ class App extends React.Component {
     this.onChange = (editorState) => {
       this.setState({ editorState });
     };
+
+    this.refsEditor = React.createRefs()
+
   }
 
   componentDidMount() {
-    this.refs.editor.focus();
+    this.refsEditor.current.focus();
   }
 
   render() {
     const { editorState } = this.state;
     return (
       <Editor
-        ref="editor"
+        ref={this.refsEditor}
         editorState={editorState}
         onChange={this.onChange}
         sideButtons={this.sideButtons}


### PR DESCRIPTION
I update README.md for example Usage in ReactJS.
https://reactjs.org/docs/refs-and-the-dom.html

thanks 