### PR TITLE
Fix url handling

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -209,7 +209,7 @@ class MediumDraftEditor extends React.Component {
     let newUrl = url;
     if (this.props.processURL) {
       newUrl = this.props.processURL(url);
-    } else if (url.indexOf('http') === -1) {
+    } else if (url.indexOf('http') !== 0 && url.indexOf('mailto:') !== 0) {
       if (url.indexOf('@') >= 0) {
         newUrl = `mailto:${newUrl}`;
       } else {


### PR DESCRIPTION
Small change to the link handling.

With this PR:
* Links with without the prefix 'http', but with 'http' inside the
link/text will now be prefixed with 'http://'
* Links with the prefix 'mailto:' will not get another 'mailto:' after
being edited. *PS*: This bug is very annoying :laughing: 

This algorithm (if we can call it that) should probably be tested, but then it have to be extracted into a separate function. Ill let that be up to the maintainers. :smile:


Otherwise, awesome editor! Thanks for your work :beer: 