### PR TITLE
Update toolbar to fix positioning bug and overflow off screen

### DIFF
--- a/src/components/toolbar.js
+++ b/src/components/toolbar.js
@@ -97,23 +97,18 @@ export default class Toolbar extends React.Component {
     toolbarNode.style.top =
       `${(selectionBoundary.top - parentBoundary.top - toolbarBoundary.height - 5)}px`;
     toolbarNode.style.width = `${toolbarBoundary.width}px`;
-    const widthDiff = selectionBoundary.width - toolbarBoundary.width;
-    if (widthDiff >= 0) {
-      toolbarNode.style.left = `${widthDiff / 2}px`;
-    } else {
-      const left = (selectionBoundary.left - parentBoundary.left);
-      toolbarNode.style.left = `${left + (widthDiff / 2)}px`;
-      // toolbarNode.style.width = toolbarBoundary.width + 'px';
-      // if (left + toolbarBoundary.width > parentBoundary.width) {
-        // toolbarNode.style.right = '0px';
-        // toolbarNode.style.left = '';
-        // toolbarNode.style.width = toolbarBoundary.width + 'px';
-      // }
-      // else {
-      //   toolbarNode.style.left = (left + widthDiff / 2) + 'px';
-      //   toolbarNode.style.right = '';
-      // }
+
+    // The left side of the tooltip should be:
+    // center of selection relative to parent - half width of toolbar
+    const selectionCenter = (selectionBoundary.left + (selectionBoundary.width / 2)) - parentBoundary.left;
+    let left = selectionCenter - (toolbarBoundary.width / 2);
+    const screenLeft = parentBoundary.left + left;
+    if (screenLeft < 0) {
+      // If the toolbar would be off-screen
+      // move it as far left as it can without going off-screen
+      left = -parentBoundary.left;
     }
+    toolbarNode.style.left = `${left}px`;
   }
 
   onKeyDown(e) {
@@ -370,4 +365,3 @@ export const INLINE_BUTTONS = [
     description: 'Add a link',
   },
 ];
-


### PR DESCRIPTION
1. Fix issue where tooltip is positioned wrong if the selection is wider than the tooltip
2. Made tooltip not overflow left edge of viewport

**Example 1 before fix**
![1-old](https://user-images.githubusercontent.com/2937410/50388207-68049c00-06c4-11e9-95aa-5d52670c9f3a.png)

**Example 1 after fix**
![1-new](https://user-images.githubusercontent.com/2937410/50388208-68049c00-06c4-11e9-9d58-c3140c982282.png)

**Example 2 before fix**
![2-old](https://user-images.githubusercontent.com/2937410/50388209-68049c00-06c4-11e9-8e90-ad6ffa31097c.png)

**Example 2 after fix**
![2-new](https://user-images.githubusercontent.com/2937410/50388210-689d3280-06c4-11e9-807e-ecf13f8e1d57.png)