### PR TITLE
Keep add button visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,11 @@ The importer is available as `MediumDraftImporter` global;
   // Use this editorState
 ```
 
+### Keep AddButton visible
+
+If you need the "+" button to be visible always, use `addButtonAutoclose={false}`
+
+
 ### Issues
 
 - [x] Write an exporter to export draft data to HTML specifically for `medium-draft`.

--- a/src/components/addbutton.js
+++ b/src/components/addbutton.js
@@ -122,7 +122,7 @@ export default class AddButton extends React.Component {
   }
 
   render() {
-    if (!this.state.visible) {
+    if (!this.state.visible && this.props.addButtonAutoclose) {
       return null;
     }
     return (

--- a/src/components/addbutton.js
+++ b/src/components/addbutton.js
@@ -173,4 +173,5 @@ AddButton.propTypes = {
   getEditorState: PropTypes.func.isRequired,
   setEditorState: PropTypes.func.isRequired,
   sideButtons: PropTypes.arrayOf(PropTypes.object),
+  addButtonAutoclose: PropTypes.bool.isRequired,
 };

--- a/src/editor.js
+++ b/src/editor.js
@@ -89,6 +89,7 @@ class MediumDraftEditor extends React.Component {
     showLinkEditToolbar: PropTypes.bool,
     toolbarConfig: PropTypes.object,
     processURL: PropTypes.func,
+    addButtonAutoclose: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -121,6 +122,7 @@ class MediumDraftEditor extends React.Component {
     disableToolbar: false,
     showLinkEditToolbar: true,
     toolbarConfig: {},
+    addButtonAutoclose: true,
   };
 
   constructor(props) {
@@ -556,6 +558,7 @@ class MediumDraftEditor extends React.Component {
               setEditorState={this.onChange}
               focus={this.focus}
               sideButtons={this.props.sideButtons}
+              addButtonAutoclose={this.props.addButtonAutoclose}
             />
           )}
           {!disableToolbar && (


### PR DESCRIPTION
Seems like a good idea to have an option to keep the **Add button** always visible, because when you start typing it disappears until you go to the next line.