### PR TITLE
Hide side toolbar when editor does not have focus.

### DIFF
--- a/src/components/addbutton.js
+++ b/src/components/addbutton.js
@@ -60,7 +60,7 @@ export default class AddButton extends React.Component {
         this.hideBlock();
       } else {
         this.setState({
-          visible: true && hasFocus,
+          visible: hasFocus,
         });
       }
       return;
@@ -117,7 +117,7 @@ export default class AddButton extends React.Component {
     // const rect = node.getBoundingClientRect();
     this.node = node;
     this.setState({
-      visible: true && hasFocus,
+      visible: hasFocus,
       style: {
         top: node.offsetTop - 3,
       },

--- a/src/components/addbutton.js
+++ b/src/components/addbutton.js
@@ -34,6 +34,7 @@ export default class AddButton extends React.Component {
     const { editorState } = newProps;
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
+    const hasFocus = editorState.getSelection().getHasFocus();
     if (!selectionState.isCollapsed() || selectionState.anchorKey !== selectionState.focusKey || contentState.getBlockForKey(selectionState.getAnchorKey()).getType().indexOf('atomic') >= 0) {
       // console.log('no sel');
       this.hideBlock();
@@ -59,7 +60,7 @@ export default class AddButton extends React.Component {
         this.hideBlock();
       } else {
         this.setState({
-          visible: true,
+          visible: true && hasFocus,
         });
       }
       return;
@@ -97,6 +98,8 @@ export default class AddButton extends React.Component {
   }
 
   findNode() {
+    const { editorState } = this.props;
+    const hasFocus = editorState.getSelection().getHasFocus();
     // eslint-disable-next-line no-undef
     const node = getSelectedBlockNode(window);
     if (node === this.node) {
@@ -114,7 +117,7 @@ export default class AddButton extends React.Component {
     // const rect = node.getBoundingClientRect();
     this.node = node;
     this.setState({
-      visible: true,
+      visible: true && hasFocus,
       style: {
         top: node.offsetTop - 3,
       },


### PR DESCRIPTION
Thanks for this amazing project! 

I experienced an issue where the side toolbar would be shown when the editor does not have focus. 

![image](https://user-images.githubusercontent.com/35876827/57511846-787f8100-730a-11e9-86a2-c9fde4618bea.png)

This PR checks if the editor has focus and takes that into account when setting the visible state of the side toolbar.
