### PR TITLE
Fix special characters from being escaped twice in links

### DIFF
--- a/src/exporter.js
+++ b/src/exporter.js
@@ -118,9 +118,7 @@ export const entityToHTML = (entity, originalText) => {
         href={entity.data.url}
         target="_blank"
         rel="noopener noreferrer"
-      >
-        {originalText}
-      </a>
+      />
     );
   }
   return originalText;


### PR DESCRIPTION
See here for explanation on fix https://github.com/HubSpot/draft-convert/issues/47 . 