### PR TITLE
Adds disableLinkEdit and ToolbarComponent props

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ The strings inside the `block` and `inline` arrays must match the `style` attrib
 
 To summarize: if you need add, remove, and reorder buttons, it's probably easiest to use `blockButtons`, `inlineButtons`, and `toolbarConfig` together.
 
+#### Supply Your Own Toolbar
+
+If the toolbar customization props aren't sufficient to get the behavior you want, you can inject your own toolbar with the `ToolbarComponent` prop.
+
+This pattern is called [component injection](https://reactpatterns.github.io/Component-injection/). Your `ToolbarComponent` receives the same props as the default toolbar.
+
+If you want to write your own toolbar component, a good place to start is [with the default component](https://github.com/brijeshb42/medium-draft/blob/master/src/components/toolbar.js).
+
 ### Render data to HTML
 
 The feature to export HTML is available from version `0.4.1` onwards.

--- a/src/editor.js
+++ b/src/editor.js
@@ -564,7 +564,7 @@ class MediumDraftEditor extends React.Component {
     const blockButtons = this.configureToolbarBlockOptions(toolbarConfig);
     const inlineButtons = this.configureToolbarInlineOptions(toolbarConfig);
 
-    const Toolbar = ToolbarComponent || DefaultToolbar
+    const Toolbar = ToolbarComponent || DefaultToolbar;
 
     return (
       <div className="md-RichEditor-root">

--- a/src/editor.js
+++ b/src/editor.js
@@ -13,7 +13,7 @@ import isSoftNewlineEvent from 'draft-js/lib/isSoftNewlineEvent';
 import { OrderedMap } from 'immutable';
 
 import AddButton from './components/addbutton';
-import Toolbar, { BLOCK_BUTTONS, INLINE_BUTTONS } from './components/toolbar';
+import DefaultToolbar, { BLOCK_BUTTONS, INLINE_BUTTONS } from './components/toolbar';
 import LinkEditComponent from './components/LinkEditComponent';
 
 import rendererFn from './components/customrenderer';
@@ -91,9 +91,11 @@ class MediumDraftEditor extends React.Component {
     handleReturn: PropTypes.func,
     handlePastedText: PropTypes.func,
     disableToolbar: PropTypes.bool,
+    disableLinkEdit: PropTypes.bool,
     showLinkEditToolbar: PropTypes.bool,
     toolbarConfig: PropTypes.object,
     processURL: PropTypes.func,
+    ToolbarComponent: PropTypes.node,
   };
 
   static defaultProps = {
@@ -125,6 +127,7 @@ class MediumDraftEditor extends React.Component {
       },
     ],
     disableToolbar: false,
+    disableLinkEdit: false,
     showLinkEditToolbar: true,
     toolbarConfig: {},
   };
@@ -542,7 +545,16 @@ class MediumDraftEditor extends React.Component {
   Renders the `Editor`, `Toolbar` and the side `AddButton`.
   */
   render() {
-    const { editorState, editorEnabled, disableToolbar, showLinkEditToolbar, toolbarConfig } = this.props;
+    const {
+      editorState,
+      editorEnabled,
+      disableToolbar,
+      disableLinkEdit,
+      showLinkEditToolbar,
+      toolbarConfig,
+      ToolbarComponent,
+    } = this.props;
+
     const showAddButton = editorEnabled;
     const editorClass = `md-RichEditor-editor${!editorEnabled ? ' md-RichEditor-readonly' : ''}`;
     let isCursorLink = false;
@@ -551,6 +563,9 @@ class MediumDraftEditor extends React.Component {
     }
     const blockButtons = this.configureToolbarBlockOptions(toolbarConfig);
     const inlineButtons = this.configureToolbarInlineOptions(toolbarConfig);
+
+    const Toolbar = ToolbarComponent || DefaultToolbar
+
     return (
       <div className="md-RichEditor-root">
         <div className={editorClass}>
@@ -598,7 +613,7 @@ class MediumDraftEditor extends React.Component {
               inlineButtons={inlineButtons}
             />
           )}
-          {isCursorLink && (
+          {isCursorLink && !disableLinkEdit && (
             <LinkEditComponent
               {...isCursorLink}
               editorState={editorState}


### PR DESCRIPTION
`disableLinkEdit` is really simple. It's a boolean prop that simply prevents the `LinkEditComponent` from being rendered.

`ToolbarComponent` is more interesting. I'll just take the description from the README:

>If the toolbar customization props aren't sufficient to get the behavior you want, you can inject your own toolbar with the `ToolbarComponent` prop.

>This pattern is called [component injection](https://reactpatterns.github.io/Component-injection/). Your `ToolbarComponent` receives the same props as the default toolbar.

>If you want to write your own toolbar component, a good place to start is [with the default component](https://github.com/brijeshb42/medium-draft/blob/master/src/components/toolbar.js).
